### PR TITLE
702 - Split the external secret manager deployment out of iam

### DIFF
--- a/argo/apps/templates/sbat-iam-init-config.yaml
+++ b/argo/apps/templates/sbat-iam-init-config.yaml
@@ -1,0 +1,27 @@
+# This initializer pod will be deployed in the namespace with the environment type = 'FIDC'
+# Otherwise, currently this pod will be deployed in cdk namespace only
+# @See the pipeline initialise, step 'install_initializer_cron_job'
+
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: iam-initialiser-config-{{ .Release.Name }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    namespace: {{ .Values.spec.destination.namespace }}
+    server: {{ .Values.spec.destination.server }}
+  project: {{ .Values.spec.project }}
+  source:
+    helm:
+      parameters:
+      - name: environment.fr_platform.type
+        value: {{ .Values.environment.type }}
+    path: helm/external-secrets
+    repoURL: https://github.com/SecureApiGateway/sapig-openbanking-uk-developer-envs
+    targetRevision: {{ .Values.iamInitialiserConfig.branch }}
+  syncPolicy:
+    {{- toYaml .Values.spec.syncPolicy | nindent 4 }}

--- a/argo/apps/templates/sbat-iam-secret-manager.yaml
+++ b/argo/apps/templates/sbat-iam-secret-manager.yaml
@@ -22,6 +22,6 @@ spec:
         value: {{ .Values.environment.type }}
     path: helm/external-secrets
     repoURL: https://github.com/SecureApiGateway/sapig-openbanking-uk-developer-envs
-    targetRevision: {{ .Values.iamInitialiserConfig.branch }}
+    targetRevision: {{ .Values.iamSecretManager.branch }}
   syncPolicy:
     {{- toYaml .Values.spec.syncPolicy | nindent 4 }}

--- a/argo/apps/templates/sbat-iam-secret-manager.yaml
+++ b/argo/apps/templates/sbat-iam-secret-manager.yaml
@@ -5,7 +5,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: iam-initialiser-config-{{ .Release.Name }}
+  name: iam-secret-manager-{{ .Release.Name }}
   annotations:
     argocd.argoproj.io/sync-wave: "2"
   finalizers:

--- a/argo/apps/values.yaml
+++ b/argo/apps/values.yaml
@@ -42,6 +42,10 @@ iamInitialiser:
   tag: latest
   branch: HEAD
 
+iamInitialiserConfig:
+  tag: latest
+  branch: HEAD
+
 testUserInit:
   tag: latest
   branch: HEAD

--- a/argo/apps/values.yaml
+++ b/argo/apps/values.yaml
@@ -42,7 +42,7 @@ iamInitialiser:
   tag: latest
   branch: HEAD
 
-iamInitialiserConfig:
+iamSecretManager:
   tag: latest
   branch: HEAD
 


### PR DESCRIPTION
Have the secret created in the new [dev repo](https://github.com/SecureApiGateway/sapig-openbanking-uk-developer-envs)

Create new argo template for creating the IAM initialiser config

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/702