### PR TITLE
725-Fix mongodb not starting up

### DIFF
--- a/argo/apps/templates/mongodb.yaml
+++ b/argo/apps/templates/mongodb.yaml
@@ -20,6 +20,6 @@ spec:
       - name: auth.enabled
         value: "{{ .Values.mongodb.auth.enabled }}"
     repoURL: https://charts.bitnami.com/bitnami
-    targetRevision: 12.1.15
+    targetRevision: 13.6.1
   syncPolicy:
     {{- toYaml .Values.spec.syncPolicy | nindent 4 }}


### PR DESCRIPTION
Up the chart version for mongodb as the previous is no longer 'available' newer version tested and seems to be okay

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/725