### PR TITLE
764: Adding secrets for the Open Banking Signing Key and Test Trusted Directory Keys

### DIFF
--- a/cluster/certificate/templates/ig-ob-signing-key-secret.yaml
+++ b/cluster/certificate/templates/ig-ob-signing-key-secret.yaml
@@ -1,0 +1,11 @@
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ .Values.ig.ob.signingKey.secretName }}
+spec:
+  backendType: gcpSecretsManager
+  projectId: {{ .Values.externalCert.projectId }}
+  data:
+    - key: {{ .Values.ig.ob.signingKey.googleSecretName }}
+      name: {{ .Values.ig.ob.signingKey.fileName }}
+      version: latest

--- a/cluster/certificate/templates/ig-ob-signing-key-secret.yaml
+++ b/cluster/certificate/templates/ig-ob-signing-key-secret.yaml
@@ -9,3 +9,4 @@ spec:
     - key: {{ .Values.ig.ob.signingKey.googleSecretName }}
       name: {{ .Values.ig.ob.signingKey.fileName }}
       version: latest
+      isBinary: true

--- a/cluster/certificate/templates/ig-test-trusted-directory-secret.yaml
+++ b/cluster/certificate/templates/ig-test-trusted-directory-secret.yaml
@@ -1,0 +1,14 @@
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ .Values.ig.testTrustedDirectory.secretName }}
+spec:
+  backendType: gcpSecretsManager
+  projectId: {{ .Values.externalCert.projectId }}
+  data:
+    - key: {{ .Values.ig.testTrustedDirectory.ca.googleSecretName }}
+      name: {{ .Values.ig.testTrustedDirectory.ca.fileName }}
+      version: latest
+    - key: { { .Values.ig.testTrustedDirectory.signingKey.googleSecretName } }
+      name: { { .Values.ig.testTrustedDirectory.signingKey.fileName } }
+      version: latest

--- a/cluster/certificate/templates/ig-test-trusted-directory-secret.yaml
+++ b/cluster/certificate/templates/ig-test-trusted-directory-secret.yaml
@@ -9,6 +9,8 @@ spec:
     - key: {{ .Values.ig.testTrustedDirectory.ca.googleSecretName }}
       name: {{ .Values.ig.testTrustedDirectory.ca.fileName }}
       version: latest
+      isBinary: true
     - key: {{ .Values.ig.testTrustedDirectory.signingKey.googleSecretName }}
       name: {{ .Values.ig.testTrustedDirectory.signingKey.fileName }}
       version: latest
+      isBinary: true

--- a/cluster/certificate/templates/ig-test-trusted-directory-secret.yaml
+++ b/cluster/certificate/templates/ig-test-trusted-directory-secret.yaml
@@ -9,6 +9,6 @@ spec:
     - key: {{ .Values.ig.testTrustedDirectory.ca.googleSecretName }}
       name: {{ .Values.ig.testTrustedDirectory.ca.fileName }}
       version: latest
-    - key: { { .Values.ig.testTrustedDirectory.signingKey.googleSecretName } }
-      name: { { .Values.ig.testTrustedDirectory.signingKey.fileName } }
+    - key: {{ .Values.ig.testTrustedDirectory.signingKey.googleSecretName }}
+      name: {{ .Values.ig.testTrustedDirectory.signingKey.fileName }}
       version: latest

--- a/cluster/certificate/values.yaml
+++ b/cluster/certificate/values.yaml
@@ -22,5 +22,5 @@ ig:
       fileName: ca.p12
       googleSecretName: test-trusted-dir-ca-key
     signingKey:
-      fileName: test-authority-signing-key.p12
+      fileName: test-trusted-directory-signing-key.p12
       googleSecretName: test-trusted-dir-signing-key

--- a/cluster/certificate/values.yaml
+++ b/cluster/certificate/values.yaml
@@ -11,3 +11,16 @@ ig:
     secretName: ig-truststore-pem
     fileName: ig-truststore.pem
     googleSecretName: ig-truststore-pem
+  ob:
+    signingKey:
+      secretName: ig-ob-signing-key
+      fileName: ig-ob-signing-key.p12
+      googleSecretName: ig-ob-signing-key
+  testTrustedDirectory:
+    secretName: test-trusted-dir-keys
+    ca:
+      fileName: ca.p12
+      googleSecretName: test-trusted-dir-ca-key
+    signingKey:
+      fileName: test-authority-signing-key.p12
+      googleSecretName: test-trusted-dir-signing-key


### PR DESCRIPTION
ig-ob-signing-key-secret.yaml represents the JWT signing key to sign Open Banking API response messages (OBSeal)

ig-test-trusted-directory-secret.yaml contains secrets required for IG to run a Test Trusted Directory. The CA secret is the signing key used to sign the certificates issued by the authority. The signingKey secret is used to sign the SSA JWTs issued by the directory.

https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/764