### PR TITLE
764: Combining test trusted directory ca and signing key secrets into a single keystore

### DIFF
--- a/cluster/certificate/templates/ig-test-trusted-directory-secret.yaml
+++ b/cluster/certificate/templates/ig-test-trusted-directory-secret.yaml
@@ -6,11 +6,7 @@ spec:
   backendType: gcpSecretsManager
   projectId: {{ .Values.externalCert.projectId }}
   data:
-    - key: {{ .Values.ig.testTrustedDirectory.ca.googleSecretName }}
-      name: {{ .Values.ig.testTrustedDirectory.ca.fileName }}
-      version: latest
-      isBinary: true
-    - key: {{ .Values.ig.testTrustedDirectory.signingKey.googleSecretName }}
-      name: {{ .Values.ig.testTrustedDirectory.signingKey.fileName }}
+    - key: {{ .Values.ig.testTrustedDirectory.googleSecretName }}
+      name: {{ .Values.ig.testTrustedDirectory.fileName }}
       version: latest
       isBinary: true

--- a/cluster/certificate/values.yaml
+++ b/cluster/certificate/values.yaml
@@ -17,10 +17,6 @@ ig:
       fileName: ig-ob-signing-key.p12
       googleSecretName: ig-ob-signing-key
   testTrustedDirectory:
-    secretName: test-trusted-dir-keys
-    ca:
-      fileName: ca.p12
-      googleSecretName: test-trusted-dir-ca-key
-    signingKey:
-      fileName: test-trusted-directory-signing-key.p12
-      googleSecretName: test-trusted-dir-signing-key
+    secretName: test-trusted-dir-keystore
+    fileName: test-trusted-dir-keystore.p12
+    googleSecretName: test-trusted-dir-keystore


### PR DESCRIPTION
New Google Secret: `test-trusted-dir-keystore` contains both the ca private key and the jwt-signing private key.

Managing one store & secret simplifies the process of setting up the Test Trusted Directory.

https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/764