### PR TITLE
Replace use of deprecated external-secrets-manager

### DIFF
--- a/cluster/certificate/templates/cert-secret.yaml
+++ b/cluster/certificate/templates/cert-secret.yaml
@@ -1,16 +1,20 @@
-apiVersion: kubernetes-client.io/v1
+apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: {{ .Values.externalCert.secretName }}
 spec:
-  backendType: gcpSecretsManager
-  template:
-    type: kubernetes.io/tls
-  projectId: {{ .Values.externalCert.projectId }}
+  refreshInterval: 1h             
+  secretStoreRef:
+    kind: SecretStore
+    name: gcp-store               
+  target:
+    name: {{ .Values.externalCert.secretName }} 
+    creationPolicy: Owner
   data:
-    - key: {{ .Values.externalCert.certPrefix }}-crt
-      name: tls.crt
-      version: latest
-    - key: {{ .Values.externalCert.certPrefix }}-key
-      name: tls.key
-      version: latest
+  - secretKey: tls.crt
+    remoteRef:
+      key: {{ .Values.externalCert.certPrefix }}-crt
+  - secretKey: tls.key
+    remoteRef:
+      key: {{ .Values.externalCert.certPrefix }}-key
+

--- a/cluster/certificate/templates/ig-ob-signing-key-secret.yaml
+++ b/cluster/certificate/templates/ig-ob-signing-key-secret.yaml
@@ -1,12 +1,16 @@
-apiVersion: kubernetes-client.io/v1
+apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: {{ .Values.ig.ob.signingKey.secretName }}
 spec:
-  backendType: gcpSecretsManager
-  projectId: {{ .Values.externalCert.projectId }}
+  refreshInterval: 1h             
+  secretStoreRef:
+    kind: SecretStore
+    name: gcp-store               
+  target:
+    name: {{ .Values.ig.ob.signingKey.secretName }}
+    creationPolicy: Owner
   data:
-    - key: {{ .Values.ig.ob.signingKey.googleSecretName }}
-      name: {{ .Values.ig.ob.signingKey.fileName }}
-      version: latest
-      isBinary: true
+  - secretKey: {{ .Values.ig.ob.signingKey.fileName }}
+    remoteRef:
+      key: {{ .Values.ig.ob.signingKey.googleSecretName }}

--- a/cluster/certificate/templates/ig-test-trusted-directory-secret.yaml
+++ b/cluster/certificate/templates/ig-test-trusted-directory-secret.yaml
@@ -1,12 +1,16 @@
-apiVersion: kubernetes-client.io/v1
+apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: {{ .Values.ig.testTrustedDirectory.secretName }}
 spec:
-  backendType: gcpSecretsManager
-  projectId: {{ .Values.externalCert.projectId }}
+  refreshInterval: 1h             
+  secretStoreRef:
+    kind: SecretStore
+    name: gcp-store               
+  target:
+    name: {{ .Values.ig.testTrustedDirectory.secretName }}
+    creationPolicy: Owner
   data:
-    - key: {{ .Values.ig.testTrustedDirectory.googleSecretName }}
-      name: {{ .Values.ig.testTrustedDirectory.fileName }}
-      version: latest
-      isBinary: true
+  - secretKey: {{ .Values.ig.testTrustedDirectory.fileName }}
+    remoteRef:
+      key: {{ .Values.ig.testTrustedDirectory.googleSecretName }}

--- a/cluster/certificate/templates/ig-truststore-secret.yaml
+++ b/cluster/certificate/templates/ig-truststore-secret.yaml
@@ -1,11 +1,16 @@
-apiVersion: kubernetes-client.io/v1
+apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: {{ .Values.ig.truststore.secretName }}
 spec:
-  backendType: gcpSecretsManager
-  projectId: {{ .Values.externalCert.projectId }}
+  refreshInterval: 1h             
+  secretStoreRef:
+    kind: SecretStore
+    name: gcp-store               
+  target:
+    name: {{ .Values.ig.truststore.secretName }}
+    creationPolicy: Owner
   data:
-    - key: {{ .Values.ig.truststore.googleSecretName }}
-      name: {{ .Values.ig.truststore.fileName }}
-      version: latest
+  - secretKey: {{ .Values.ig.truststore.fileName }}
+    remoteRef:
+      key: {{ .Values.ig.truststore.googleSecretName }}

--- a/cluster/certificate/templates/ob-cert-secret.yaml
+++ b/cluster/certificate/templates/ob-cert-secret.yaml
@@ -1,16 +1,19 @@
-apiVersion: kubernetes-client.io/v1
+apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: {{ .Values.openBankingCert.secretName }}
 spec:
-  backendType: gcpSecretsManager
-  template:
-    type: kubernetes.io/tls
-  projectId: {{ .Values.externalCert.projectId }}
+  refreshInterval: 1h             
+  secretStoreRef:
+    kind: SecretStore
+    name: gcp-store               
+  target:
+    name: {{ .Values.openBankingCert.secretName }}
+    creationPolicy: Owner
   data:
-    - key: {{ .Values.openBankingCert.certPrefix }}-crt
-      name: tls.crt
-      version: latest
-    - key: {{ .Values.openBankingCert.certPrefix }}-key
-      name: tls.key
-      version: latest
+  - secretKey: tls.crt
+    remoteRef:
+      key: {{ .Values.openBankingCert.certPrefix }}-crt
+  - secretKey: tls.key
+    remoteRef:
+      key: {{ .Values.openBankingCert.certPrefix }}-key

--- a/cluster/certificate/templates/rcs-signing-secret.yaml
+++ b/cluster/certificate/templates/rcs-signing-secret.yaml
@@ -1,14 +1,19 @@
-apiVersion: kubernetes-client.io/v1
+apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: {{ .Values.rcs.signing.secretName }}
 spec:
-  backendType: gcpSecretsManager
-  projectId: {{ .Values.externalCert.projectId }}
+  refreshInterval: 1h             
+  secretStoreRef:
+    kind: SecretStore
+    name: gcp-store               
+  target:
+    name: {{ .Values.rcs.signing.secretName }}
+    creationPolicy: Owner
   data:
-    - key: {{ .Values.rcs.signing.certPrefix }}-crt
-      name: rcs-signing.pem
-      version: latest
-    - key: {{ .Values.rcs.signing.certPrefix }}-key
-      name: rcs-signing.key
-      version: latest
+  - secretKey: rcs-signing.pem
+    remoteRef:
+      key: {{ .Values.rcs.signing.certPrefix }}-crt
+  - secretKey: rcs-signing.key
+    remoteRef:
+      key: {{ .Values.rcs.signing.certPrefix }}-key


### PR DESCRIPTION
As we are using a new repo for our externalsecrets we need to change the manifests to accommodate

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/766