### PR TITLE
934: Rename the apps in the values file for argo apps

### DIFF
--- a/argo/apps/templates/fidc-configurator.yaml
+++ b/argo/apps/templates/fidc-configurator.yaml
@@ -27,9 +27,9 @@ spec:
       - name: deployment.imageOverride.iam_initializer_image_name
         value: secureopenbanking-uk-iam-initializer
       - name: deployment.imageOverride.iam_initializer_image_tag
-        value: {{ .Values.iamInitialiser.tag }}
+        value: {{ .Values.fidc-configurator.tag }}
     path: _infra/helm/securebanking-openbanking-uk-iam-initializer
     repoURL: https://github.com/SecureBankingAccessToolkit/securebanking-openbanking-uk-fidc-initializer
-    targetRevision: {{ .Values.iamInitialiser.branch }}
+    targetRevision: {{ .Values.fidc-configurator.branch }}
   syncPolicy:
     {{- toYaml .Values.spec.syncPolicy | nindent 4 }}

--- a/argo/apps/templates/remote-consent-server.yaml
+++ b/argo/apps/templates/remote-consent-server.yaml
@@ -17,11 +17,11 @@ spec:
       - name: ingress.domain
         value: {{ .Values.ingress.domain }}
       - name: deployment.imageOverride.tag
-        value: {{ .Values.rcs.tag }}
+        value: {{ .Values.remote-consent-server.tag }}
       - name: deployment.cors.originEnds
         value: {{ .Values.cors.originEnds }}
     path: _infra/helm/securebanking-openbanking-uk-rcs
     repoURL: https://github.com/SecureBankingAccessToolkit/securebanking-openbanking-uk-rcs
-    targetRevision: {{ .Values.rcs.branch }}
+    targetRevision: {{ .Values.remote-consent-server.branch }}
   syncPolicy:
     {{- toYaml .Values.spec.syncPolicy | nindent 4 }}

--- a/argo/apps/templates/remote-consent-ui.yaml
+++ b/argo/apps/templates/remote-consent-ui.yaml
@@ -15,11 +15,11 @@ spec:
     helm:
       parameters:
       - name: rcsUI.deployment.imageOverride.tag
-        value: {{ .Values.ui.tag }}
+        value: {{ .Values.remote-consent-ui.tag }}
       - name: rcsUI.deployment.templateName
-        value: {{ .Values.ui.templateName }}
+        value: {{ .Values.remote-consent-ui.templateName }}
     path: _infra/helm/securebanking-ui
     repoURL: https://github.com/SecureBankingAccessToolkit/securebanking-ui
-    targetRevision: {{ .Values.ui.branch }}
+    targetRevision: {{ .Values.remote-consent-ui.branch }}
   syncPolicy:
     {{- toYaml .Values.spec.syncPolicy | nindent 4 }}

--- a/argo/apps/templates/test-facility-bank.yaml
+++ b/argo/apps/templates/test-facility-bank.yaml
@@ -19,7 +19,7 @@ spec:
       - name: mongodb.host
         value: "mongodb-{{ .Release.Name }}"
       - name: deployment.imageOverride.tag
-        value: {{ .Values.rs.tag }}
+        value: {{ .Values.test-facility-bank.tag }}
       values: |
         springConfig:
           testdata:
@@ -57,6 +57,6 @@ spec:
 
     path: _infra/helm/securebanking-openbanking-uk-rs
     repoURL: https://github.com/SecureBankingAccessToolkit/securebanking-openbanking-uk-rs
-    targetRevision: {{ .Values.rs.branch }}
+    targetRevision: {{ .Values.test-facility-bank.branch }}
   syncPolicy:
     {{- toYaml .Values.spec.syncPolicy | nindent 4 }}

--- a/argo/apps/templates/test-user-account-creator.yaml
+++ b/argo/apps/templates/test-user-account-creator.yaml
@@ -27,11 +27,11 @@ spec:
       - name: deployment.imageOverride.test_data_initializer_image_name
         value: securebanking-test-data-initializer
       - name: deployment.imageOverride.test_data_initializer_tag
-        value: {{ .Values.testUserInit.tag }}
+        value: {{ .Values.test-user-account-creator.tag }}
       - name: deploymentType
-        value: {{ .Values.testUserInit.deploymentType }}      
+        value: {{ .Values.test-user-account-creator.deploymentType }}
     path: _infra/helm/securebanking-test-data-initializer
     repoURL: https://github.com/SecureBankingAccessToolkit/securebanking-openbanking-test-data-initializer
-    targetRevision: {{ .Values.testUserInit.branch }}
+    targetRevision: {{ .Values.test-user-account-creator.branch }}
   syncPolicy:
     {{- toYaml .Values.spec.syncPolicy | nindent 4 }}

--- a/argo/apps/values.yaml
+++ b/argo/apps/values.yaml
@@ -17,15 +17,15 @@ ingress:
 cors:
   originEnds: localhost
 
-rcs:
+remote-consent-server:
   tag: latest
   branch: HEAD
 
-rs:
+test-facility-bank:
   tag: latest
   branch: HEAD
 
-ui:
+remote-consent-ui:
   tag: latest
   branch: HEAD
   templateName: forgerock
@@ -37,7 +37,7 @@ ig:
     # Reusing the secret that configures AM to trust CAs for OAuth 2.0 tls_client_auth
     googleSecretName: am-oauth2-ca-certs
 
-iamInitialiser:
+fidc-configurator:
   tag: latest
   branch: HEAD
 
@@ -45,7 +45,7 @@ iamSecretManager:
   tag: latest
   branch: HEAD
 
-testUserInit:
+test-user-account-creator:
   tag: latest
   branch: HEAD
   deploymentType: CronJob


### PR DESCRIPTION
The values being set in argocd parameters are not matching those used by the argo application templates.

Everything needs to match up again!

Issue: https://github.com/secureapigateway/secureapigateway/issues/934