### PR TITLE
934: Use camelcase for values as '-' causes errors in yaml

### DIFF
--- a/argo/apps/templates/fidc-configurator.yaml
+++ b/argo/apps/templates/fidc-configurator.yaml
@@ -27,9 +27,9 @@ spec:
       - name: deployment.imageOverride.iam_initializer_image_name
         value: secureopenbanking-uk-iam-initializer
       - name: deployment.imageOverride.iam_initializer_image_tag
-        value: {{ .Values.fidc-configurator.tag }}
+        value: {{ .Values.fidcConfigurator.tag }}
     path: _infra/helm/securebanking-openbanking-uk-iam-initializer
     repoURL: https://github.com/SecureBankingAccessToolkit/securebanking-openbanking-uk-fidc-initializer
-    targetRevision: {{ .Values.fidc-configurator.branch }}
+    targetRevision: {{ .Values.fidcConfigurator.branch }}
   syncPolicy:
     {{- toYaml .Values.spec.syncPolicy | nindent 4 }}

--- a/argo/apps/templates/remote-consent-server.yaml
+++ b/argo/apps/templates/remote-consent-server.yaml
@@ -17,11 +17,11 @@ spec:
       - name: ingress.domain
         value: {{ .Values.ingress.domain }}
       - name: deployment.imageOverride.tag
-        value: {{ .Values.remote-consent-server.tag }}
+        value: {{ .Values.remoteConsentServer.tag }}
       - name: deployment.cors.originEnds
         value: {{ .Values.cors.originEnds }}
     path: _infra/helm/securebanking-openbanking-uk-rcs
     repoURL: https://github.com/SecureBankingAccessToolkit/securebanking-openbanking-uk-rcs
-    targetRevision: {{ .Values.remote-consent-server.branch }}
+    targetRevision: {{ .Values.remoteConsentServer.branch }}
   syncPolicy:
     {{- toYaml .Values.spec.syncPolicy | nindent 4 }}

--- a/argo/apps/templates/remote-consent-ui.yaml
+++ b/argo/apps/templates/remote-consent-ui.yaml
@@ -15,11 +15,11 @@ spec:
     helm:
       parameters:
       - name: rcsUI.deployment.imageOverride.tag
-        value: {{ .Values.remote-consent-ui.tag }}
+        value: {{ .Values.remoteConsentUi.tag }}
       - name: rcsUI.deployment.templateName
-        value: {{ .Values.remote-consent-ui.templateName }}
+        value: {{ .Values.remoteConsentUi.templateName }}
     path: _infra/helm/securebanking-ui
     repoURL: https://github.com/SecureBankingAccessToolkit/securebanking-ui
-    targetRevision: {{ .Values.remote-consent-ui.branch }}
+    targetRevision: {{ .Values.remoteConsentUi.branch }}
   syncPolicy:
     {{- toYaml .Values.spec.syncPolicy | nindent 4 }}

--- a/argo/apps/templates/test-facility-bank.yaml
+++ b/argo/apps/templates/test-facility-bank.yaml
@@ -19,7 +19,7 @@ spec:
       - name: mongodb.host
         value: "mongodb-{{ .Release.Name }}"
       - name: deployment.imageOverride.tag
-        value: {{ .Values.test-facility-bank.tag }}
+        value: {{ .Values.testFacilityBank.tag }}
       values: |
         springConfig:
           testdata:
@@ -57,6 +57,6 @@ spec:
 
     path: _infra/helm/securebanking-openbanking-uk-rs
     repoURL: https://github.com/SecureBankingAccessToolkit/securebanking-openbanking-uk-rs
-    targetRevision: {{ .Values.test-facility-bank.branch }}
+    targetRevision: {{ .Values.testFacilityBank.branch }}
   syncPolicy:
     {{- toYaml .Values.spec.syncPolicy | nindent 4 }}

--- a/argo/apps/templates/test-user-account-creator.yaml
+++ b/argo/apps/templates/test-user-account-creator.yaml
@@ -27,11 +27,11 @@ spec:
       - name: deployment.imageOverride.test_data_initializer_image_name
         value: securebanking-test-data-initializer
       - name: deployment.imageOverride.test_data_initializer_tag
-        value: {{ .Values.test-user-account-creator.tag }}
+        value: {{ .Values.testUserAccountCreator.tag }}
       - name: deploymentType
-        value: {{ .Values.test-user-account-creator.deploymentType }}
+        value: {{ .Values.testUserAccountCreator.deploymentType }}
     path: _infra/helm/securebanking-test-data-initializer
     repoURL: https://github.com/SecureBankingAccessToolkit/securebanking-openbanking-test-data-initializer
-    targetRevision: {{ .Values.test-user-account-creator.branch }}
+    targetRevision: {{ .Values.testUserAccountCreator.branch }}
   syncPolicy:
     {{- toYaml .Values.spec.syncPolicy | nindent 4 }}

--- a/argo/apps/values.yaml
+++ b/argo/apps/values.yaml
@@ -17,15 +17,15 @@ ingress:
 cors:
   originEnds: localhost
 
-remote-consent-server:
+remoteConsentServer:
   tag: latest
   branch: HEAD
 
-test-facility-bank:
+testFacilityBank:
   tag: latest
   branch: HEAD
 
-remote-consent-ui:
+remoteConsentUi:
   tag: latest
   branch: HEAD
   templateName: forgerock
@@ -37,7 +37,7 @@ ig:
     # Reusing the secret that configures AM to trust CAs for OAuth 2.0 tls_client_auth
     googleSecretName: am-oauth2-ca-certs
 
-fidc-configurator:
+fidcConfigurator:
   tag: latest
   branch: HEAD
 
@@ -45,7 +45,7 @@ iamSecretManager:
   tag: latest
   branch: HEAD
 
-test-user-account-creator:
+testUserAccountCreator:
   tag: latest
   branch: HEAD
   deploymentType: CronJob


### PR DESCRIPTION
Using - in value names causes parse issues in YAML 

Revert to using camel case for the values

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/934