### PR TITLE
901 Disable initializer for nightly env

### DIFF
--- a/argo/apps/templates/fidc-configurator.yaml
+++ b/argo/apps/templates/fidc-configurator.yaml
@@ -25,7 +25,7 @@ spec:
       - name: cronjob.image.tag
         value: {{ .Values.fidcConfigurator.tag }}
       - name: cronjob.enabled
-        value: {{ .Values.fidcConfigurator.cronjob.enabled | quote }}
+        value: {{ .Values.fidcConfigurator.enabled | quote }}
     path: _infra/helm/securebanking-openbanking-uk-iam-initializer
     repoURL: https://github.com/SecureBankingAccessToolkit/securebanking-openbanking-uk-fidc-initializer
     targetRevision: {{ .Values.fidcConfigurator.branch }}

--- a/argo/apps/templates/fidc-configurator.yaml
+++ b/argo/apps/templates/fidc-configurator.yaml
@@ -24,6 +24,8 @@ spec:
         value: {{ .Values.fidcConfigurator.repo}}
       - name: cronjob.image.tag
         value: {{ .Values.fidcConfigurator.tag }}
+      - name: cronjob.enabled
+        value: {{ .Values.fidcConfigurator.cronjob.enabled | quote }}
     path: _infra/helm/securebanking-openbanking-uk-iam-initializer
     repoURL: https://github.com/SecureBankingAccessToolkit/securebanking-openbanking-uk-fidc-initializer
     targetRevision: {{ .Values.fidcConfigurator.branch }}

--- a/argo/apps/values.yaml
+++ b/argo/apps/values.yaml
@@ -14,6 +14,7 @@ externalCert:
   certPrefix: dev
 
 fidcConfigurator:
+  enabled: true
   branch: HEAD
   repo: eu.gcr.io/sbat-gcr-develop/securebanking/secureopenbanking-uk-iam-initializer
   tag: latest


### PR DESCRIPTION
Add in new env variable for toggling the fidc configurator to be installed or not, by default it is true and for nightly we are setting it to false during the pipeline

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/901