### PR TITLE
1070: customer info account data spring config

### DIFF
--- a/argo/apps/templates/test-facility-bank.yaml
+++ b/argo/apps/templates/test-facility-bank.yaml
@@ -35,6 +35,9 @@ spec:
                   - sortCode: "334412"
                     accountNumber: "30187862"
             rs:
+              data:
+                customerInfo:
+                  enabled: true
               discovery:
                 versions:
                   v3.0: false


### PR DESCRIPTION
To be able disabled or enabled to support push customer info account data has been added new spring properties
- Added spring properties to enabled or disabled support to push customer info account data using DataApi
- Enabled by default for devs environments

This property is false by default when rs.data.customerInfo.enabled property isn't provided in the configuration or environment variable. Not needs to be set in relenvs environments, in relenvs environments must be always disabled.

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1070