### PR TITLE
601 added funds confirmation API to discovery endpoint

### DIFF
--- a/argo/apps/templates/test-facility-bank.yaml
+++ b/argo/apps/templates/test-facility-bank.yaml
@@ -54,8 +54,6 @@ spec:
                   v3.1.10: true
                 apis:
                   # These APIs are not currently implemented
-                  CREATE_FUNDS_CONFIRMATION: false
-                  GET_FUNDS_CONFIRMATION: false
                   CREATE_CALLBACK_URL: false
                   GET_CALLBACK_URLS: false
                   AMEND_CALLBACK_URL: false


### PR DESCRIPTION
- deleted disabled funds confirmation APIS from test facility bank to be added in RS discovery

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/601