### PR TITLE
1315: Remove unwanted config from dev-core

### DIFF
--- a/argo/apps/core/templates/namespace-init.yaml
+++ b/argo/apps/core/templates/namespace-init.yaml
@@ -22,8 +22,8 @@ spec:
         value: {{ .Values.ig.truststore.googleSecretName }}
       - name: ig.ob.signingkey.googleSecretName
         value: {{ .Values.ig.ob.signingkey.googleSecretName }}
-      - name: openBankingCert.certPrefix
-        value: {{ .Values.openBankingCert.certPrefix }}
+      - name: environment.sapigType
+        value: {{ .Values.environment.sapigType }}
     path: cluster/certificate
     repoURL: https://github.com/SecureBankingAccessToolkit/sbat-cd
     targetRevision: {{ .Values.spec.source.targetRevision }}

--- a/argo/apps/ob/templates/namespace-init.yaml
+++ b/argo/apps/ob/templates/namespace-init.yaml
@@ -22,6 +22,8 @@ spec:
         value: {{ .Values.ig.truststore.googleSecretName }}
       - name: ig.ob.signingkey.googleSecretName
         value: {{ .Values.ig.ob.signingkey.googleSecretName }}
+      - name: environment.sapigType
+        value: {{ .Values.environment.sapigType }}
       - name: openBankingCert.certPrefix
         value: {{ .Values.openBankingCert.certPrefix }}
     path: cluster/certificate

--- a/cluster/certificate/templates/ob-cert-secret.yaml
+++ b/cluster/certificate/templates/ob-cert-secret.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.environment.sapigType "ob" }}
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
@@ -17,3 +18,4 @@ spec:
   - secretKey: tls.key
     remoteRef:
       key: {{ .Values.openBankingCert.certPrefix }}-key
+{{ end }}

--- a/cluster/certificate/values.yaml
+++ b/cluster/certificate/values.yaml
@@ -1,4 +1,7 @@
 
+environment:
+  sapigType: ob
+
 serviceAccount: default
 
 externalCert:


### PR DESCRIPTION
Don't want OB secrets being created for Core, will use value of env.sapigType for wherever to create or not

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1315