### PR TITLE
1315: Add OBWac back into Core and remove RCS Signing Key

### DIFF
--- a/cluster/certificate/templates/ob-cert-secret.yaml
+++ b/cluster/certificate/templates/ob-cert-secret.yaml
@@ -1,4 +1,3 @@
-{{- if eq .Values.environment.sapigType "ob" }}
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
@@ -18,4 +17,3 @@ spec:
   - secretKey: tls.key
     remoteRef:
       key: {{ .Values.openBankingCert.certPrefix }}-key
-{{ end }}

--- a/cluster/certificate/templates/rcs-signing-secret.yaml
+++ b/cluster/certificate/templates/rcs-signing-secret.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.environment.sapigType "ob" }}
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
@@ -17,3 +18,4 @@ spec:
   - secretKey: rcs-signing.key
     remoteRef:
       key: {{ .Values.rcs.signing.certPrefix }}-key
+{{ end }}


### PR DESCRIPTION
- OBWac is required for the time being for mtls ingresses 
- RCS Signing key is not required in core

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1315