### PR TITLE
1315: Remove unwanted config from dev-core

### DIFF
--- a/cluster/certificate/templates/ig-ob-signing-key-secret.yaml
+++ b/cluster/certificate/templates/ig-ob-signing-key-secret.yaml
@@ -1,3 +1,5 @@
+---
+{{- if eq .Values.environment.sapigType ob }}
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
@@ -14,3 +16,4 @@ spec:
   - secretKey: {{ .Values.ig.ob.signingKey.fileName }}
     remoteRef:
       key: {{ .Values.ig.ob.signingKey.googleSecretName }}
+{{ end }}


### PR DESCRIPTION
We only want ig-ob-signing-key-secret to be created in the cluster if the sapig type is OB

Removed reference from the key in IG deployment in the following [PR](https://github.com/SecureApiGateway/sapig-openbanking-uk-developer-envs/pull/98)

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1315