### PR TITLE
1362: Try improve sync timings of components being created in ArgoCD

### DIFF
--- a/argo/apps/core/templates/sbat-iam-secret-manager.yaml
+++ b/argo/apps/core/templates/sbat-iam-secret-manager.yaml
@@ -7,7 +7,7 @@ kind: Application
 metadata:
   name: iam-secret-manager-{{ .Release.Name }}
   annotations:
-    argocd.argoproj.io/sync-wave: "2"
+    argocd.argoproj.io/sync-wave: "1"
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:

--- a/argo/apps/core/templates/test-user-account-creator.yaml
+++ b/argo/apps/core/templates/test-user-account-creator.yaml
@@ -7,7 +7,7 @@ kind: Application
 metadata:
   name: test-user-account-creator-{{ .Release.Name }}
   annotations:
-    argocd.argoproj.io/sync-wave: "2"
+    argocd.argoproj.io/sync-wave: "3"
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:

--- a/argo/apps/ob/templates/remote-consent-server.yaml
+++ b/argo/apps/ob/templates/remote-consent-server.yaml
@@ -3,7 +3,7 @@ kind: Application
 metadata:
   name: remote-consent-server-{{ .Release.Name }}
   annotations:
-    argocd.argoproj.io/sync-wave: "3"
+    argocd.argoproj.io/sync-wave: "4"
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:

--- a/argo/apps/ob/templates/remote-consent-ui.yaml
+++ b/argo/apps/ob/templates/remote-consent-ui.yaml
@@ -3,7 +3,7 @@ kind: Application
 metadata:
   name: remote-consent-ui-{{ .Release.Name }}
   annotations:
-    argocd.argoproj.io/sync-wave: "2"
+    argocd.argoproj.io/sync-wave: "4"
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:

--- a/argo/apps/ob/templates/sbat-iam-secret-manager.yaml
+++ b/argo/apps/ob/templates/sbat-iam-secret-manager.yaml
@@ -7,7 +7,7 @@ kind: Application
 metadata:
   name: iam-secret-manager-{{ .Release.Name }}
   annotations:
-    argocd.argoproj.io/sync-wave: "2"
+    argocd.argoproj.io/sync-wave: "1"
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:

--- a/argo/apps/ob/templates/test-facility-bank.yaml
+++ b/argo/apps/ob/templates/test-facility-bank.yaml
@@ -3,7 +3,7 @@ kind: Application
 metadata:
   name: test-facility-bank-{{ .Release.Name }}
   annotations:
-    argocd.argoproj.io/sync-wave: "3"
+    argocd.argoproj.io/sync-wave: "4"
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:

--- a/argo/apps/ob/templates/test-user-account-creator.yaml
+++ b/argo/apps/ob/templates/test-user-account-creator.yaml
@@ -7,7 +7,7 @@ kind: Application
 metadata:
   name: test-user-account-creator-{{ .Release.Name }}
   annotations:
-    argocd.argoproj.io/sync-wave: "2"
+    argocd.argoproj.io/sync-wave: "3"
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:


### PR DESCRIPTION
- The test initialiser seems to rely on the CDK / Cloud instance being created and configured, so have this component created after IG & FIDC Initialiser has ran (they rely on each other) 

- Set sbat-iam-secret-manager to 1 as it doesn't reply on anything else either

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1362