### PR TITLE
1459: Cleanup use of sapigType in test init

### DIFF
--- a/argo/apps/ob/templates/test-user-account-creator.yaml
+++ b/argo/apps/ob/templates/test-user-account-creator.yaml
@@ -26,8 +26,6 @@ spec:
         value: {{ .Values.testUserAccountCreator.tag }}
       - name: deployment.type
         value: {{ .Values.testUserAccountCreator.deployment.type }}
-      - name: cronjob.environment.sapigType
-        value: ob
     path: _infra/helm/securebanking-test-data-initializer
     repoURL: https://github.com/SecureBankingAccessToolkit/securebanking-openbanking-test-data-initializer
     targetRevision: {{ .Values.testUserAccountCreator.branch }}


### PR DESCRIPTION
Remove override of sapigType as being set by configmap

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1459