### PR TITLE
1533: Create cloud config for am-fahrenheit & use nightly-core env to test

### DIFF
--- a/argo/apps/core/templates/namespace-init.yaml
+++ b/argo/apps/core/templates/namespace-init.yaml
@@ -30,6 +30,10 @@ spec:
         value: {{ .Values.environment.sapigType }}
       - name: environment.cloudType
         value: {{ .Values.environment.cloudType }}
+      - name: cloud.id
+        value: {{ .Values.cloud.key }}
+      - name: cloud.key
+        value: {{ .Values.cloud.key }}
     path: cluster/certificate
     repoURL: https://github.com/SecureBankingAccessToolkit/sbat-cd
     targetRevision: {{ .Values.spec.source.targetRevision }}

--- a/argo/apps/core/values.yaml
+++ b/argo/apps/core/values.yaml
@@ -1,4 +1,8 @@
 ---
+cloud:
+  id: nightly-core-private-id
+  key: nightly-core-private-key
+
 cors:
   originEnds: localhost
 

--- a/argo/apps/ob/templates/namespace-init.yaml
+++ b/argo/apps/ob/templates/namespace-init.yaml
@@ -30,6 +30,10 @@ spec:
         value: {{ .Values.environment.sapigType }}
       - name: environment.cloudType
         value: {{ .Values.environment.cloudType }}
+      - name: cloud.id
+        value: {{ .Values.cloud.key }}
+      - name: cloud.key
+        value: {{ .Values.cloud.key }}
     path: cluster/certificate
     repoURL: https://github.com/SecureBankingAccessToolkit/sbat-cd
     targetRevision: {{ .Values.spec.source.targetRevision }}

--- a/argo/apps/ob/values.yaml
+++ b/argo/apps/ob/values.yaml
@@ -1,4 +1,8 @@
 ---
+cloud:
+  id: nightly-private-id
+  key: nightly-private-key
+
 cors:
   originEnds: localhost
 

--- a/cluster/certificate/templates/cloud-service-account.yaml
+++ b/cluster/certificate/templates/cloud-service-account.yaml
@@ -15,8 +15,8 @@ spec:
   data:
   - secretKey: private-key
     remoteRef:
-      key: nightly-private-key
+      key: {{ .Values.cloud.key }}
   - secretKey: private-id
     remoteRef:
-      key: nightly-private-id
+      key: {{ .Values.cloud.id }}
 {{ end }}

--- a/cluster/certificate/values.yaml
+++ b/cluster/certificate/values.yaml
@@ -1,3 +1,6 @@
+cloud:
+  id: nightly-private-id
+  key: nightly-private-key
 
 environment:
   sapigType: ob


### PR DESCRIPTION
Add in new cloud service account env vars, by default the nightly-private-key|id was being used, seeing as this is a new tenant the service account doesnt exist. Need a way of using a different secret for the test Core deployment

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1533