### PR TITLE
1609: Fix nightly Core - Use SAPIG Nightly AIC tenant

### DIFF
--- a/argo/apps/core/values.yaml
+++ b/argo/apps/core/values.yaml
@@ -1,7 +1,7 @@
 ---
 cloud:
-  id: nightly-core-private-id
-  key: nightly-core-private-key
+  id: nightly-private-id
+  key: nightly-private-id
 
 cors:
   originEnds: localhost


### PR DESCRIPTION
 Revert back to using nightly keys for service cloud

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1609