### PR TITLE
1670: Move Kustomize base templates to individual repos

### DIFF
--- a/argo/apps/core/templates/ig.yaml
+++ b/argo/apps/core/templates/ig.yaml
@@ -12,12 +12,11 @@ spec:
     server: {{ .Values.spec.destination.server }}
   project: {{ .Values.spec.project }}
   source:
-    path: core/kustomize/overlay/{{ .Values.environment.kustomizeFolder }}
+    path: core/kustomize/overlay/{{ .Values.environment.kustomizeFolder }}/core
     repoURL: https://github.com/SecureApiGateway/sapig-openbanking-uk-developer-envs
-    targetRevision: {{ .Values.ig.branch }}
+    targetRevision: {{ .Values.devenvs.ig.branch }}
     kustomize:
       images:
-        - europe-west4-docker.pkg.dev/sbat-gcr-develop/sapig-docker-artifact/securebanking/sapig-core:{{ .Values.ig.tag }}
-        - europe-west4-docker.pkg.dev/sbat-gcr-develop/sapig-docker-artifact/securebanking/sapig-test-trusted-directory:{{ .Values.testTrustedDirectory.tag }}
+        - europe-west4-docker.pkg.dev/sbat-gcr-develop/sapig-docker-artifact/securebanking/sapig-core:{{ .Values.devenvs.ig.tag }}
   syncPolicy:
     {{- toYaml .Values.spec.syncPolicy | nindent 4 }}

--- a/argo/apps/core/templates/namespace-init.yaml
+++ b/argo/apps/core/templates/namespace-init.yaml
@@ -5,7 +5,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "1"
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+    - resources-finalizer.argocd.argoproj.io
 spec:
   destination:
     namespace: {{ .Values.spec.destination.namespace }}
@@ -14,26 +14,26 @@ spec:
   source:
     helm:
       parameters:
-      - name: externalCert.projectId
-        value: {{ .Values.externalCert.projectId }}
-      - name: externalCert.mtls.certPrefix
-        value: {{ .Values.externalCert.mtls.certPrefix }}
-      - name: externalCert.sapig.certPrefix
-        value: {{ .Values.externalCert.sapig.certPrefix }}
-      - name: externalCert.ttd.certPrefix
-        value: {{ .Values.externalCert.ttd.certPrefix }}
-      - name: ig.truststore.googleSecretName
-        value: {{ .Values.ig.truststore.googleSecretName }}
-      - name: ig.ob.signingkey.googleSecretName
-        value: {{ .Values.ig.ob.signingkey.googleSecretName }}
-      - name: environment.sapigType
-        value: {{ .Values.environment.sapigType }}
-      - name: environment.cloudType
-        value: {{ .Values.environment.cloudType }}
-      - name: cloud.id
-        value: {{ .Values.cloud.id }}
-      - name: cloud.key
-        value: {{ .Values.cloud.key }}
+        - name: externalCert.projectId
+          value: {{ .Values.externalCert.projectId }}
+        - name: externalCert.mtls.certPrefix
+          value: {{ .Values.externalCert.mtls.certPrefix }}
+        - name: externalCert.sapig.certPrefix
+          value: {{ .Values.externalCert.sapig.certPrefix }}
+        - name: externalCert.ttd.certPrefix
+          value: {{ .Values.externalCert.ttd.certPrefix }}
+        - name: ig.truststore.googleSecretName
+          value: {{ .Values.devenvs.ig.truststore.googleSecretName }}
+        - name: ig.ob.signingkey.googleSecretName
+          value: {{ .Values.devenvs.ig.ob.signingkey.googleSecretName }}
+        - name: environment.sapigType
+          value: {{ .Values.environment.sapigType }}
+        - name: environment.cloudType
+          value: {{ .Values.environment.cloudType }}
+        - name: cloud.id
+          value: {{ .Values.cloud.id }}
+        - name: cloud.key
+          value: {{ .Values.cloud.key }}
     path: cluster/certificate
     repoURL: https://github.com/SecureBankingAccessToolkit/sbat-cd
     targetRevision: {{ .Values.spec.source.targetRevision }}

--- a/argo/apps/core/templates/test-trusted-directory.yaml
+++ b/argo/apps/core/templates/test-trusted-directory.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: ig-{{ .Release.Name }}
+  name: test-trusted-directory-{{ .Release.Name }}
   annotations:
     argocd.argoproj.io/sync-wave: "2"
   finalizers:
@@ -12,11 +12,11 @@ spec:
     server: {{ .Values.spec.destination.server }}
   project: {{ .Values.spec.project }}
   source:
-    path: ob/kustomize/overlay/{{ .Values.environment.kustomizeFolder }}/ob
+    path: core/kustomize/overlay/{{ .Values.environment.kustomizeFolder }}/testtrusteddir
     repoURL: https://github.com/SecureApiGateway/sapig-openbanking-uk-developer-envs
-    targetRevision: {{ .Values.devenvs.ig.branch }}
+    targetRevision: {{ .Values.devenvs.testTrustedDirectory.branch }}
     kustomize:
       images:
-        - europe-west4-docker.pkg.dev/sbat-gcr-develop/sapig-docker-artifact/securebanking/ig:{{ .Values.devenvs.ig.tag }}
+        - europe-west4-docker.pkg.dev/sbat-gcr-develop/sapig-docker-artifact/securebanking/sapig-test-trusted-directory:{{ .Values.devenvs.testTrustedDirectory.tag }}
   syncPolicy:
     {{- toYaml .Values.spec.syncPolicy | nindent 4 }}

--- a/argo/apps/core/values.yaml
+++ b/argo/apps/core/values.yaml
@@ -32,15 +32,19 @@ fidcConfigurator:
   repo: europe-west4-docker.pkg.dev/sbat-gcr-develop/sapig-docker-artifact/securebanking/secureopenbanking-uk-iam-initializer
   tag: latest
 
-ig:
-  tag: latest
-  branch: HEAD
-  truststore:
-    # Reusing the secret that configures AM to trust CAs for OAuth 2.0 tls_client_auth
-    googleSecretName: am-oauth2-ca-certs
-  ob:
-    signingkey:
-      googleSecretName: ig-ob-signing-key
+devenvs:
+  ig:
+    tag: latest
+    branch: HEAD
+    truststore:
+      # Reusing the secret that configures AM to trust CAs for OAuth 2.0 tls_client_auth
+      googleSecretName: am-oauth2-ca-certs
+    ob:
+      signingkey:
+        googleSecretName: ig-ob-signing-key
+  testTrustedDirectory:
+    tag: latest
+    branch: HEAD
 
 ingress:
   domain: localhost
@@ -56,9 +60,6 @@ spec:
     automated:
       prune: true
       selfHeal: true
-
-testTrustedDirectory:
-  tag: latest
 
 testUserAccountCreator:
   branch: HEAD

--- a/argo/apps/core/values.yaml
+++ b/argo/apps/core/values.yaml
@@ -35,7 +35,7 @@ fidcConfigurator:
 devenvs:
   ig:
     tag: latest
-    branch: HEAD
+    branch: master
     truststore:
       # Reusing the secret that configures AM to trust CAs for OAuth 2.0 tls_client_auth
       googleSecretName: am-oauth2-ca-certs
@@ -44,7 +44,7 @@ devenvs:
         googleSecretName: ig-ob-signing-key
   testTrustedDirectory:
     tag: latest
-    branch: HEAD
+    branch: master
 
 ingress:
   domain: localhost

--- a/argo/apps/ob/templates/namespace-init.yaml
+++ b/argo/apps/ob/templates/namespace-init.yaml
@@ -5,7 +5,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "1"
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+    - resources-finalizer.argocd.argoproj.io
 spec:
   destination:
     namespace: {{ .Values.spec.destination.namespace }}
@@ -14,26 +14,26 @@ spec:
   source:
     helm:
       parameters:
-      - name: externalCert.projectId
-        value: {{ .Values.externalCert.projectId }}
-      - name: externalCert.mtls.certPrefix
-        value: {{ .Values.externalCert.mtls.certPrefix }}
-      - name: externalCert.sapig.certPrefix
-        value: {{ .Values.externalCert.sapig.certPrefix }}
-      - name: externalCert.ttd.certPrefix
-        value: {{ .Values.externalCert.ttd.certPrefix }}
-      - name: ig.truststore.googleSecretName
-        value: {{ .Values.ig.truststore.googleSecretName }}
-      - name: ig.ob.signingkey.googleSecretName
-        value: {{ .Values.ig.ob.signingkey.googleSecretName }}
-      - name: environment.sapigType
-        value: {{ .Values.environment.sapigType }}
-      - name: environment.cloudType
-        value: {{ .Values.environment.cloudType }}
-      - name: cloud.id
-        value: {{ .Values.cloud.id }}
-      - name: cloud.key
-        value: {{ .Values.cloud.key }}
+        - name: externalCert.projectId
+          value: {{ .Values.externalCert.projectId }}
+        - name: externalCert.mtls.certPrefix
+          value: {{ .Values.externalCert.mtls.certPrefix }}
+        - name: externalCert.sapig.certPrefix
+          value: {{ .Values.externalCert.sapig.certPrefix }}
+        - name: externalCert.ttd.certPrefix
+          value: {{ .Values.externalCert.ttd.certPrefix }}
+        - name: ig.truststore.googleSecretName
+          value: {{ .Values.devenvs.ig.truststore.googleSecretName }}
+        - name: ig.ob.signingkey.googleSecretName
+          value: {{ .Values.devenvs.ig.ob.signingkey.googleSecretName }}
+        - name: environment.sapigType
+          value: {{ .Values.environment.sapigType }}
+        - name: environment.cloudType
+          value: {{ .Values.environment.cloudType }}
+        - name: cloud.id
+          value: {{ .Values.cloud.id }}
+        - name: cloud.key
+          value: {{ .Values.cloud.key }}
     path: cluster/certificate
     repoURL: https://github.com/SecureBankingAccessToolkit/sbat-cd
     targetRevision: {{ .Values.spec.source.targetRevision }}

--- a/argo/apps/ob/templates/test-trusted-directory.yaml
+++ b/argo/apps/ob/templates/test-trusted-directory.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: ig-{{ .Release.Name }}
+  name: test-trusted-directory-{{ .Release.Name }}
   annotations:
     argocd.argoproj.io/sync-wave: "2"
   finalizers:
@@ -12,11 +12,11 @@ spec:
     server: {{ .Values.spec.destination.server }}
   project: {{ .Values.spec.project }}
   source:
-    path: ob/kustomize/overlay/{{ .Values.environment.kustomizeFolder }}/ob
+    path: ob/kustomize/overlay/{{ .Values.environment.kustomizeFolder }}/testtrusteddir
     repoURL: https://github.com/SecureApiGateway/sapig-openbanking-uk-developer-envs
-    targetRevision: {{ .Values.devenvs.ig.branch }}
+    targetRevision: {{ .Values.devenvs.testTrustedDirectory.branch }}
     kustomize:
       images:
-        - europe-west4-docker.pkg.dev/sbat-gcr-develop/sapig-docker-artifact/securebanking/ig:{{ .Values.devenvs.ig.tag }}
+        - europe-west4-docker.pkg.dev/sbat-gcr-develop/sapig-docker-artifact/securebanking/sapig-test-trusted-directory:{{ .Values.devenvs.testTrustedDirectory.tag }}
   syncPolicy:
     {{- toYaml .Values.spec.syncPolicy | nindent 4 }}

--- a/argo/apps/ob/values.yaml
+++ b/argo/apps/ob/values.yaml
@@ -31,16 +31,19 @@ fidcConfigurator:
   branch: HEAD
   repo: europe-west4-docker.pkg.dev/sbat-gcr-develop/sapig-docker-artifact/securebanking/secureopenbanking-uk-iam-initializer
   tag: latest
-
-ig:
-  tag: latest
-  branch: HEAD
-  truststore:
-    # Reusing the secret that configures AM to trust CAs for OAuth 2.0 tls_client_auth
-    googleSecretName: am-oauth2-ca-certs
-  ob:
-    signingkey:
-      googleSecretName: ig-ob-signing-key
+devenvs:
+  ig:
+    tag: latest
+    branch: HEAD
+    truststore:
+      # Reusing the secret that configures AM to trust CAs for OAuth 2.0 tls_client_auth
+      googleSecretName: am-oauth2-ca-certs
+    ob:
+      signingkey:
+        googleSecretName: ig-ob-signing-key
+  testTrustedDirectory:
+    tag: latest
+    branch: HEAD
 
 ingress:
   domain: localhost

--- a/argo/apps/ob/values.yaml
+++ b/argo/apps/ob/values.yaml
@@ -34,7 +34,7 @@ fidcConfigurator:
 devenvs:
   ig:
     tag: latest
-    branch: HEAD
+    branch: master
     truststore:
       # Reusing the secret that configures AM to trust CAs for OAuth 2.0 tls_client_auth
       googleSecretName: am-oauth2-ca-certs
@@ -43,7 +43,7 @@ devenvs:
         googleSecretName: ig-ob-signing-key
   testTrustedDirectory:
     tag: latest
-    branch: HEAD
+    branch: master
 
 ingress:
   domain: localhost


### PR DESCRIPTION
- Need to amend previous ig template to only deploy core|ob
- New template to deploy the TTD

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1670