### PR TITLE
1676: Split IG into AS/RS and deploy to Devenvs

### DIFF
--- a/argo/apps/core/values.yaml
+++ b/argo/apps/core/values.yaml
@@ -16,6 +16,10 @@ environment:
 
 externalCert:
   projectId: example-project
+  # TODO: Need to remove in future to configure ttd to have its own mtls cert
+  mtls:
+    certPrefix: dev
+    secretName: mtls-tls-cert
   fapiPepAS:
     mtlsSecretName: fapi-pep-as-mtls-tls-cert
     mtlsCertPrefix: dev-ob-wac

--- a/cluster/certificate/templates/mtls-cert-secret.yaml
+++ b/cluster/certificate/templates/mtls-cert-secret.yaml
@@ -1,5 +1,4 @@
 ---
-{{- if eq .Values.environment.sapigType "ob" }}
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
@@ -19,4 +18,3 @@ spec:
   - secretKey: tls.key
     remoteRef:
       key: {{ .Values.externalCert.mtls.certPrefix }}-key
-{{ end }}


### PR DESCRIPTION
Use existing mtls cert for TTD for the time being

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1676