### PR TITLE
OpenIG-9515: FAPI Conformance Suite (Tests)

### DIFF
--- a/argo/apps/core/templates/fapi-pep-as.yaml
+++ b/argo/apps/core/templates/fapi-pep-as.yaml
@@ -27,6 +27,8 @@ spec:
           value: {{ .Values.fapiPepAs.configmap.asFQDN }}
         - name: configmap.asMtlsFQDN
           value: {{ .Values.fapiPepAs.configmap.asMtlsFQDN }}
+        - name: configmap.igOBASPSPSigningKid
+          value: {{ .Values.fapiPepAs.configmap.igOBASPSPSigningKid }}
         - name: configmap.sapigType
           value: {{ .Values.fapiPepAs.configmap.sapigType }}
         - name: configmap.testDirectoryFQDN

--- a/argo/apps/core/values.yaml
+++ b/argo/apps/core/values.yaml
@@ -43,6 +43,7 @@ fapiPepAs:
     baseFQDN: "dev-cdk-core.forgerock.financial"
     cloudType: "CDK"
     identityPlatformFQDN: "iam.dev-cdk-core.forgerock.financial"
+    igOBASPSPSigningKid: "4n8h20rzgJc4RM_8Uf3t98P6QcA"
     sapigType: "core"
     testDirectoryFQDN: "test-trusted-directory.dev-cdk-core.forgerock.financial"
     identityDefaultUserAuthenticationService: "PasswordGrant"


### PR DESCRIPTION
Allow the signing kid to be overwritten for fapi-pep-as

Issue: https://pingidentity.atlassian.net/browse/OPENIG-9515