### PR TITLE
Fix sampleTrustedDirectory keystore password key names for ob

### DIFF
--- a/argo/apps/ob/values.yaml
+++ b/argo/apps/ob/values.yaml
@@ -164,11 +164,11 @@ sampleTrustedDirectory:
   config:
     fqdn: "test-trusted-directory.dev-cdk-ob.forgerock.financial"
     ca:
-      keystoreKeypass: "UGFzc3cwcmQ="
-      keystoreStorepass: "UGFzc3cwcmQ="
+      keystoreKeyPwd: "UGFzc3cwcmQ="
+      keystorePwd: "UGFzc3cwcmQ="
     signing:
-      keystoreKeypass: "UGFzc3cwcmQ="
-      keystoreStorepass: "UGFzc3cwcmQ="
+      keystoreKeyPwd: "UGFzc3cwcmQ="
+      keystorePwd: "UGFzc3cwcmQ="
   deployment:
     image:
       repo: "gcr.io/forgerock-io/ig-sample-trusted-directory/docker-build"


### PR DESCRIPTION
Use keystoreKeyPwd/keystorePwd to match the Helm chart secret template, not keystoreKeypass/keystoreStorepass which left all secret values null.