### PR TITLE
Remove igTruststorePassword and testDirectoryFQDN from configuration

### DIFF
--- a/argo/apps/core/templates/fapi-pep-as.yaml
+++ b/argo/apps/core/templates/fapi-pep-as.yaml
@@ -72,8 +72,6 @@ spec:
           value: {{ .Values.fapiPepAs.secrets.igMetricsPassword }}
         - name: secrets.igMetricsUsername
           value: {{ .Values.fapiPepAs.secrets.igMetricsUsername }}
-        - name: secrets.igTruststorePassword
-          value: {{ .Values.fapiPepAs.secrets.igTruststorePassword }}
     path: _infra/helm/secure-api-gateway-fapi-pep-as
     repoURL: https://github.com/SecureApiGateway/secure-api-gateway-fapi-pep-as
     targetRevision: {{ .Values.fapiPepAs.branch }}

--- a/argo/apps/core/templates/fapi-pep-rs.yaml
+++ b/argo/apps/core/templates/fapi-pep-rs.yaml
@@ -31,8 +31,6 @@ spec:
           value: {{ .Values.fapiPepRs.configmap.rsMtlsFQDN }}
         - name: configmap.sapigType
           value: {{ .Values.fapiPepRs.configmap.sapigType }}
-        - name: configmap.testDirectoryFQDN
-          value: {{ .Values.fapiPepRs.configmap.testDirectoryFQDN }}
         - name: configmap.userObject
           value: {{ .Values.fapiPepRs.configmap.userObject }}
         - name: configmap.AIC.identityDefaultUserAuthenticationService
@@ -74,8 +72,6 @@ spec:
           value: {{ .Values.fapiPepRs.secrets.igMetricsPassword }}
         - name: secrets.igMetricsUsername
           value: {{ .Values.fapiPepRs.secrets.igMetricsUsername }}
-        - name: secrets.igTruststorePassword
-          value: {{ .Values.fapiPepRs.secrets.igTruststorePassword }}
     path: _infra/helm/secure-api-gateway-fapi-pep-rs-core
     repoURL: https://github.com/SecureApiGateway/secure-api-gateway-fapi-pep-rs-core
     targetRevision: {{ .Values.fapiPepRs.branch }}

--- a/argo/apps/core/values.yaml
+++ b/argo/apps/core/values.yaml
@@ -69,7 +69,6 @@ fapiPepAs:
     igIDMUser: "c2VydmljZV9hY2NvdW50Lmln"
     igMetricsPassword: "cGFzc3dvcmQ="
     igMetricsUsername: "dXNlcg=="
-    igTruststorePassword: "Y2hhbmdlaXQ="
 
 fapiPepRs:
   branch: "HEAD"
@@ -82,7 +81,6 @@ fapiPepRs:
     rsFQDN: "rs-sapig.dev-cdk-core.forgerock.financial"
     rsMtlsFQDN: "rs-mtls.sapig.dev-cdk-core.forgerock.financial"
     sapigType: "core"
-    testDirectoryFQDN: "test-trusted-directory.dev-cdk-core.forgerock.financial"
     userObject: "user"
     identityDefaultUserAuthenticationService: "PasswordGrant"
     identityGoogleSecretStoreName: "ESV"
@@ -110,7 +108,6 @@ fapiPepRs:
     igIDMUser: "c2VydmljZV9hY2NvdW50Lmln"
     igMetricsPassword: "cGFzc3dvcmQ="
     igMetricsUsername: "dXNlcg=="
-    igTruststorePassword: "Y2hhbmdlaXQ="
 
 fidcConfigurator:
   enabled: "true"

--- a/argo/apps/ob/templates/fapi-pep-as.yaml
+++ b/argo/apps/ob/templates/fapi-pep-as.yaml
@@ -72,8 +72,6 @@ spec:
           value: {{ .Values.fapiPepAs.secrets.igMetricsPassword }}
         - name: secrets.igMetricsUsername
           value: {{ .Values.fapiPepAs.secrets.igMetricsUsername }}
-        - name: secrets.igTruststorePassword
-          value: {{ .Values.fapiPepAs.secrets.igTruststorePassword }}
     path: _infra/helm/secure-api-gateway-fapi-pep-as
     repoURL: https://github.com/SecureApiGateway/secure-api-gateway-fapi-pep-as
     targetRevision: {{ .Values.fapiPepAs.branch }}

--- a/argo/apps/ob/templates/fapi-pep-rs.yaml
+++ b/argo/apps/ob/templates/fapi-pep-rs.yaml
@@ -33,8 +33,6 @@ spec:
           value: {{ .Values.fapiPepRs.configmap.igOBASPSPSigningKid }}
         - name: configmap.sapigType
           value: {{ .Values.fapiPepRs.configmap.sapigType }}
-        - name: configmap.testDirectoryFQDN
-          value: {{ .Values.fapiPepRs.configmap.testDirectoryFQDN }}
         - name: configmap.userObject
           value: {{ .Values.fapiPepRs.configmap.userObject }}
         - name: configmap.AIC.identityDefaultUserAuthenticationService
@@ -80,8 +78,6 @@ spec:
           value: {{ .Values.fapiPepRs.secrets.igOBASPSPSigningKeystoreKeypass }}
         - name: secrets.igOBASPSPSigningKeystoreStorepass
           value: {{ .Values.fapiPepRs.secrets.igOBASPSPSigningKeystoreStorepass }}
-        - name: secrets.igTruststorePassword
-          value: {{ .Values.fapiPepRs.secrets.igTruststorePassword }}
         - name: secrets.mongodbConsentPassword
           value: {{ .Values.fapiPepRs.secrets.mongodbConsentPassword }}
         - name: secrets.mongodbConsentUsername

--- a/argo/apps/ob/values.yaml
+++ b/argo/apps/ob/values.yaml
@@ -72,7 +72,6 @@ fapiPepAs:
     igIDMUser: "c2VydmljZV9hY2NvdW50Lmln"
     igMetricsPassword: "cGFzc3dvcmQ="
     igMetricsUsername: "dXNlcg=="
-    igTruststorePassword: "Y2hhbmdlaXQ="
 
 fapiPepRs:
   branch: "HEAD"
@@ -86,7 +85,6 @@ fapiPepRs:
     rsFQDN: "rs-sapig.dev-cdk-ob.forgerock.financial"
     rsMtlsFQDN: "rs-mtls.sapig.dev-cdk-ob.forgerock.financial"
     sapigType: "ob"
-    testDirectoryFQDN: "test-trusted-directory.dev-cdk-ob.forgerock.financial"
     userObject: "user"
     identityDefaultUserAuthenticationService: "PasswordGrant"
     identityGoogleSecretStoreName: "ESV"
@@ -116,7 +114,6 @@ fapiPepRs:
     igMetricsUsername: "dXNlcg=="
     igOBASPSPSigningKeystoreKeypass: "cGFzc3dvcmQ="
     igOBASPSPSigningKeystoreStorepass: "cGFzc3dvcmQ="
-    igTruststorePassword: "Y2hhbmdlaXQ="
     mongodbConsentPassword: "TDNoNXd4czRkRnZW"
     mongodbConsentUsername: "Y29uc2VudA=="
     mongodbTestFacilityPassword: "UlZkYjdZdlg5NjdR"


### PR DESCRIPTION
Purpose of this PR is to clean the configuration according to recent changes on AS and RS configuration