### PR TITLE
Use new ig-fapi-pep-rs configuration and update parameters

### DIFF
--- a/argo/apps/core/templates/fapi-pep-rs.yaml
+++ b/argo/apps/core/templates/fapi-pep-rs.yaml
@@ -14,66 +14,56 @@ spec:
   source:
     helm:
       parameters:
-        # ConfigMap
-        - name: configmap.amRealm
-          value: {{ .Values.fapiPepRs.configmap.amRealm }}
-        - name: configmap.baseFQDN
-          value: {{ .Values.fapiPepRs.configmap.baseFQDN }}
-        - name: configmap.cloudType
-          value: {{ .Values.fapiPepRs.configmap.cloudType }}
-        - name: configmap.identityPlatformFQDN
-          value: {{ .Values.fapiPepRs.configmap.identityPlatformFQDN }}
-        - name: configmap.asFQDN
-          value: {{ .Values.fapiPepRs.configmap.asFQDN }}
-        - name: configmap.rsFQDN
-          value: {{ .Values.fapiPepRs.configmap.rsFQDN }}
-        - name: configmap.rsMtlsFQDN
-          value: {{ .Values.fapiPepRs.configmap.rsMtlsFQDN }}
-        - name: configmap.sapigType
-          value: {{ .Values.fapiPepRs.configmap.sapigType }}
-        - name: configmap.userObject
-          value: {{ .Values.fapiPepRs.configmap.userObject }}
-        - name: configmap.AIC.identityDefaultUserAuthenticationService
-          value: {{ .Values.fapiPepRs.configmap.identityDefaultUserAuthenticationService }}
-        - name: configmap.AIC.identityGoogleSecretStoreName
-          value: {{ .Values.fapiPepRs.configmap.identityGoogleSecretStoreName }}
-        - name: configmap.AIC.identityGoogleSecretStoreOAuth2CACertsSecretName
-          value: {{ .Values.fapiPepRs.configmap.identityGoogleSecretStoreOAuth2CACertsSecretName }}
+        # Authorization Server
+        - name: authorizationServer.realm
+          value: {{ .Values.fapiPepRs.authorizationServer.realm }}
+        - name: authorizationServer.fqdn
+          value: {{ .Values.fapiPepRs.authorizationServer.fqdn }}
+        - name: authorizationServer.baseFqdn
+          value: {{ .Values.fapiPepRs.authorizationServer.baseFqdn }}
+        # Identity Platform
+        - name: identityPlatform.fqdn
+          value: {{ .Values.fapiPepRs.identityPlatform.fqdn }}
+        - name: identityPlatform.type
+          value: {{ .Values.fapiPepRs.identityPlatform.type }}
+        - name: identityPlatform.userObject
+          value: {{ .Values.fapiPepRs.identityPlatform.userObject }}
+        # Resource Server
+        - name: resourceServer.fqdn
+          value: {{ .Values.fapiPepRs.resourceServer.fqdn }}
+        - name: resourceServer.mtlsFqdn
+          value: {{ .Values.fapiPepRs.resourceServer.mtlsFqdn }}
+        - name: resourceServer.gatewayDataRepoUri
+          value: {{ .Values.fapiPepRs.resourceServer.gatewayDataRepoUri }}
+        - name: resourceServer.oauth2Client.id
+          value: {{ .Values.fapiPepRs.resourceServer.oauth2Client.id }}
+        - name: resourceServer.oauth2Client.secret
+          value: {{ .Values.fapiPepRs.resourceServer.oauth2Client.secret }}
+        - name: resourceServer.idm.user
+          value: {{ .Values.fapiPepRs.resourceServer.idm.user }}
+        - name: resourceServer.idm.password
+          value: {{ .Values.fapiPepRs.resourceServer.idm.password }}
+        # AIC
+        - name: aic.identityDefaultUserAuthenticationService
+          value: {{ .Values.fapiPepRs.aic.identityDefaultUserAuthenticationService }}
+        - name: aic.identityGoogleSecretStoreName
+          value: {{ .Values.fapiPepRs.aic.identityGoogleSecretStoreName }}
+        - name: aic.identityGoogleSecretStoreOAuth2CACertsSecretName
+          value: {{ .Values.fapiPepRs.aic.identityGoogleSecretStoreOAuth2CACertsSecretName }}
         # Deployment
         - name: deployment.image.repo
-          value: {{ .Values.fapiPepRs.deployment.image.repo}}
+          value: {{ .Values.fapiPepRs.deployment.image.repo }}
         - name: deployment.image.tag
           value: {{ .Values.fapiPepRs.deployment.image.tag }}
         # Ingress
-        - name: ingress.rsSapig.host
-          value: {{ .Values.fapiPepRs.ingress.rsSapig.host }}
-        - name: ingress.rsSapig.tls.host
-          value: {{ .Values.fapiPepRs.ingress.rsSapig.tls.host }}
-        - name: ingress.rsMtls.host
-          value: {{ .Values.fapiPepRs.ingress.rsMtls.host }}
-        - name: ingress.rsMtls.tls.host
-          value: {{ .Values.fapiPepRs.ingress.rsMtls.tls.host }}
-        - name: ingress.enableStudio
-          value: {{ .Values.fapiPepRs.ingress.enableStudio | quote }}
-        # Secrets
-        - name: secrets.igAgentID
-          value: {{ .Values.fapiPepRs.secrets.igAgentID }}
-        - name: secrets.igAgentPassword
-          value: {{ .Values.fapiPepRs.secrets.igAgentPassword }}
-        - name: secrets.igClientID
-          value: {{ .Values.fapiPepRs.secrets.igClientID }}
-        - name: secrets.igClientSecret
-          value: {{ .Values.fapiPepRs.secrets.igClientSecret }}
-        - name: secrets.igIDMPassword
-          value: {{ .Values.fapiPepRs.secrets.igIDMPassword }}
-        - name: secrets.igIDMUser
-          value: {{ .Values.fapiPepRs.secrets.igIDMUser }}
-        - name: secrets.igMetricsPassword
-          value: {{ .Values.fapiPepRs.secrets.igMetricsPassword }}
-        - name: secrets.igMetricsUsername
-          value: {{ .Values.fapiPepRs.secrets.igMetricsUsername }}
-    path: _infra/helm/secure-api-gateway-fapi-pep-rs-core
-    repoURL: https://github.com/SecureApiGateway/secure-api-gateway-fapi-pep-rs-core
+        - name: ingress.mtls.serverCertSecret
+          value: {{ .Values.fapiPepRs.ingress.mtls.serverCertSecret }}
+        - name: ingress.mtls.clientCaSecret
+          value: {{ .Values.fapiPepRs.ingress.mtls.clientCaSecret }}
+        - name: ingress.tls.serverCertSecret
+          value: {{ .Values.fapiPepRs.ingress.tls.serverCertSecret }}
+    path: openig-helm/ig-fapi-pep-rs
+    repoURL: {{ .Values.fapiPepRs.repoURL }}
     targetRevision: {{ .Values.fapiPepRs.branch }}
   syncPolicy:
     {{- toYaml .Values.spec.syncPolicy | nindent 4 }}

--- a/argo/apps/core/values.yaml
+++ b/argo/apps/core/values.yaml
@@ -59,47 +59,46 @@ fapiPepAs:
       password: "MHBlbkJhbmtpbmch"
 
 fapiPepRs:
+  repoURL: "https://github.com/ping-rocks/openig.git"
   branch: "HEAD"
-  configmap:
-    amRealm: "alpha"
-    asFQDN: "as-sapig.dev-cdk-core.forgerock.financial"
-    baseFQDN: "dev-cdk-core.forgerock.financial"
-    cloudType: "CDK"
-    identityPlatformFQDN: "iam.dev-cdk-core.forgerock.financial"
-    rsFQDN: "rs-sapig.dev-cdk-core.forgerock.financial"
-    rsMtlsFQDN: "rs-mtls.sapig.dev-cdk-core.forgerock.financial"
-    sapigType: "core"
+  authorizationServer:
+    realm: "alpha"
+    fqdn: "as-sapig.dev-cdk-core.forgerock.financial"
+    baseFqdn: "dev-cdk-core.forgerock.financial"
+  identityPlatform:
+    fqdn: "iam.dev-cdk-core.forgerock.financial"
+    type: "CDK"
     userObject: "user"
+  resourceServer:
+    fqdn: "rs-sapig.dev-cdk-core.forgerock.financial"
+    mtlsFqdn: "rs-mtls.sapig.dev-cdk-core.forgerock.financial"
+    gatewayDataRepoUri: "http://ig:80"
+    oauth2Client:
+      id: "aWctY2xpZW50"
+      secret: "cGFzc3dvcmQ="
+    idm:
+      user: "c2VydmljZV9hY2NvdW50Lmln"
+      password: "MHBlbkJhbmtpbmch"
+  aic:
     identityDefaultUserAuthenticationService: "PasswordGrant"
     identityGoogleSecretStoreName: "ESV"
     identityGoogleSecretStoreOAuth2CACertsSecretName: "esv-sapig-core-am-oauth2-ca-certs"
   deployment:
     image:
-      repo: "europe-west4-docker.pkg.dev/sbat-gcr-develop/sapig-docker-artifact/securebanking/fapi-pep-rs-core"
+      repo: "gcr.io/forgerock-io/ig-fapi-pep-rs/docker-build"
       tag: "latest"
   ingress:
-    enableStudio: true
-    rsMtls:
-      host: "rs-mtls.sapig.dev-cdk-ob.forgerock.financial"
-      tls:
-        host: "rs-mtls.sapig.dev-cdk-ob.forgerock.financial"
-    rsSapig:
-      host: "rs-sapig.dev-cdk-ob.forgerock.financial"
-      tls:
-        host: "rs-sapig.dev-cdk-ob.forgerock.financial"
-  secrets:
-    igAgentID: "aWctYWdlbnQ="
-    igAgentPassword: "cGFzc3dvcmQ="
-    igClientID: "aWctY2xpZW50"
-    igClientSecret: "cGFzc3dvcmQ="
-    igIDMPassword: "MHBlbkJhbmtpbmch"
-    igIDMUser: "c2VydmljZV9hY2NvdW50Lmln"
+    mtls:
+      serverCertSecret: "fapi-pep-rs-mtls-tls-cert"
+      clientCaSecret: "fapi-pep-rs-mtls-ca-certs"
+    tls:
+      serverCertSecret: "fapi-pep-rs-tls-cert"
 
 fidcConfigurator:
   enabled: "true"
   branch: "HEAD"
   asDeploymentConfigMap: "ig-fapi-pep-as-config"
-  rsDeploymentConfigMap: "rs-sapig-deployment-config"
+  rsDeploymentConfigMap: "ig-fapi-pep-rs-config"
   asSecret: "ig-fapi-pep-as-secrets"
   image:
     repo: "europe-west4-docker.pkg.dev/sbat-gcr-develop/sapig-docker-artifact/securebanking/secureopenbanking-uk-iam-initializer"


### PR DESCRIPTION
Align fapi-pep-rs ArgoCD Application with the new chart migrated into openig:
- Update source path to openig-helm/ig-fapi-pep-rs and repoURL from values
- Replace configmap.*/secrets.*/ingress.rsSapig.*/ingress.rsMtls.* parameters with the new authorizationServer.*/identityPlatform.*/resourceServer.*/aic.* and ingress.mtls.*/ingress.tls.* structure
- Update rsDeploymentConfigMap default to ig-fapi-pep-rs-config